### PR TITLE
chore: update manifest name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "dxt_version": "0.1",
-  "name": "Socket MCP Server",
+  "name": "Socket",
   "version": "0.0.8",
   "description": "Socket MCP server for scanning dependencies",
   "author": {


### PR DESCRIPTION
Including "MCP Server" in the name is not required given most clients show this name in the context of "MCP Servers". It results in some UI saying that phrase multiple times. Naming these should probably be named after the underlying tool