### PR TITLE
docs: add Factory installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,39 @@ To use the Socket MCP server in Windsurf:
 
 </details>
 
+<details><summary><b>Install in Factory</b></summary>
+
+[Factory](https://factory.ai) is an AI-powered software engineering platform. You can install the Socket MCP server using the Factory CLI or interactive UI.
+
+**Using the Public Server (Recommended)**
+
+Add the Socket MCP server using Factory's CLI:
+
+```bash
+droid mcp add socket https://mcp.socket.dev/ --type http
+```
+
+**Using Self-Hosted Mode (with API Key)**
+
+If you prefer to run your own instance with an API key:
+
+```bash
+droid mcp add socket "npx @socketsecurity/mcp@latest" --env SOCKET_API_KEY=your-api-key-here
+```
+
+**Using the Interactive UI**
+
+Alternatively, type `/mcp` within the Factory droid to open an interactive UI for managing MCP servers. From there you can:
+- Browse and add new servers
+- View all configured servers with status
+- Enable/disable servers
+
+After installation, the Socket MCP server will be available in your Factory droid sessions. You can now ask questions like "Check the security score for express version 4.18.2".
+
+Learn more about Factory's MCP configuration in the [Factory documentation](https://docs.factory.ai/cli/configuration/mcp).
+
+</details>
+
 </details>
 
 ### Option 2: Deploy Socket MCP Server on your machine


### PR DESCRIPTION
This PR adds Factory as an installation option in the manual installation section of the README.

## Changes

Adds a new **Install in Factory** section that includes:

### Using the Public Server (Recommended)
- Quick CLI command: `droid mcp add socket https://mcp.socket.dev/ --type http`
- No API key or authentication required

### Using Self-Hosted Mode (with API Key)
- For users who prefer to run their own instance
- Command: `droid mcp add socket "npx @socketsecurity/mcp@latest" --env SOCKET_API_KEY=your-api-key-here`

### Using the Interactive UI
- Instructions for using Factory's `/mcp` command to access an interactive UI
- Allows users to browse, add, and manage MCP servers visually

## About Factory

[Factory](https://factory.ai) is an AI-powered software engineering platform that supports MCP servers through both CLI commands and an interactive UI. Factory's MCP support is documented at https://docs.factory.ai/cli/configuration/mcp.

This follows the same pattern and structure as the existing installation instructions for Claude, VS Code, Cursor, and Windsurf.