### PR TITLE
compatibility with latest @modelcontextprotocol/sdk

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,7 +69,7 @@ let SOCKET_API_KEY = process.env['SOCKET_API_KEY'] || ''
 function buildSocketHeaders (): Record<string, string> {
   return {
     'Content-Type': 'application/json',
-    'Authorization': `Bearer ${SOCKET_API_KEY}`
+    Authorization: `Bearer ${SOCKET_API_KEY}`
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -93,7 +93,6 @@ server.registerTool(
         version: z.string().describe("The version of the dependency, use 'unknown' if not known").default('unknown'),
       })).describe('Array of packages to check'),
     }),
-    outputSchema: z.object({}),
   },
   async ({ packages }) => {
     logger.info(`Received request for ${packages.length} packages`)

--- a/index.ts
+++ b/index.ts
@@ -189,6 +189,8 @@ server.registerTool(
               .join(', ')
 
             results.push(`${purl}: ${scoreEntries}`)
+          } else {
+            results.push(`${purl}: No score found`)
           }
         }
 

--- a/index.ts
+++ b/index.ts
@@ -68,8 +68,10 @@ let SOCKET_API_KEY = process.env['SOCKET_API_KEY'] || ''
 // Build headers dynamically to reflect current API key
 function buildSocketHeaders (): Record<string, string> {
   return {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${SOCKET_API_KEY}`
+    'user-agent': `socket-mcp/${VERSION}`,
+    accept: 'application/x-ndjson',
+    'content-type': 'application/json',
+    authorization: `Bearer ${SOCKET_API_KEY}`
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -93,6 +93,9 @@ server.registerTool(
         version: z.string().describe("The version of the dependency, use 'unknown' if not known").default('unknown'),
       })).describe('Array of packages to check'),
     }),
+    annotations: {
+      readOnlyHint: true,
+    },
   },
   async ({ packages }) => {
     logger.info(`Received request for ${packages.length} packages`)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "Socket",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Socket MCP server for scanning dependencies",
   "long_description": "__Secure your code by default.__\nThe Socket MCP server brings powerful, real-time dependency scanning directly into Claude. Instantly audit packages from npm, PyPI, Cargo, and more—right inside your chats—with zero setup. Built on the Model Context Protocol (MCP), this extension automatically evaluates packages for:\n - Vulnerabilities and malware\n - Supply chain risks\n - Code quality and maintenance\n - License compliance\n\n With a single command, Claude will return detailed security scores (0–100) across five critical dimensions—helping you make informed decisions and avoid risky dependencies before they hit production.",
   "author": {

--- a/manifest.json
+++ b/manifest.json
@@ -47,6 +47,7 @@
     "vibecoding"
   ],
   "license": "MIT",
+  "privacy_policies": ["https://socket.dev/privacy"],
   "repository": {
     "type": "git",
     "url": "https://github.com/SocketDev/socket-mcp"

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": "0.1",
+  "manifest_version": "0.2",
   "name": "Socket",
   "version": "0.0.12",
   "description": "Socket MCP server for scanning dependencies",

--- a/mock-client/stdio-client.ts
+++ b/mock-client/stdio-client.ts
@@ -12,7 +12,9 @@ async function main () {
     args: ['--experimental-strip-types', serverPath],
 
     env: {
-      ...process.env,
+      ...Object.fromEntries(
+        Object.entries(process.env).filter(([, value]) => value !== undefined)
+      ) as Record<string, string>,
       SOCKET_API_KEY: process.env['SOCKET_API_KEY'] || ''
     }
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@socketsecurity/mcp",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@socketsecurity/mcp",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@anthropic-ai/mcpb": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -676,12 +676,13 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.1.tgz",
-      "integrity": "sha512-j/P+yuxXfgxb+mW7OEoRCM3G47zCTDqUPivJo/VzpjbG8I9csTXtOprCf5FfOfHK4whOJny0aHuBEON+kS7CCA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.22.0.tgz",
+      "integrity": "sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
@@ -696,7 +697,37 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1081,7 +1112,9 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1092,6 +1125,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -2710,7 +2782,9 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -2725,6 +2799,22 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -3933,7 +4023,9 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5197,7 +5289,9 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5347,6 +5441,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6423,7 +6526,9 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build-mcpb": "run-s build build-mcpb:*",
     "build-mcpb:versions_match": "node --experimental-strip-types scripts/check-versions.ts",
     "build-mcpb:validate": "npx mcpb validate ./",
+    "build-mcpb:ensure-deps": "npm install --production --ignore-scripts",
     "build-mcpb:mcpb-pack": "npx mcpb pack ./",
     "clean": "./scripts/clean.sh",
     "debug-stdio": "node --experimental-strip-types ./mock-client/debug-client.ts",
@@ -33,6 +34,8 @@
   },
   "keywords": [],
   "files": [
+    "package.json",
+    "package-lock.json",
     "index.js",
     "index.d.ts",
     "index.d.ts.map",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socketsecurity/mcp",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "main": "./index.js",
   "bin": {

--- a/test.ts
+++ b/test.ts
@@ -14,7 +14,9 @@ test('Socket MCP Server', async (t) => {
     command: 'node',
     args: ['--experimental-strip-types', serverPath],
     env: {
-      ...process.env,
+      ...Object.fromEntries(
+        Object.entries(process.env).filter(([, value]) => value !== undefined)
+      ) as Record<string, string>,
       SOCKET_API_KEY: apiKey
     }
   })


### PR DESCRIPTION
This PR adds support for the latest version of @modelcontextprotocol/sdk, which has breaking changes. The most important aspect is to switch to `registerTool` and add tool annotations for `readOnlyHint`, so that we are compatible with the Anthropic MCP Directory.