### PR TITLE
Fix origin validation for production domains

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -301,17 +301,22 @@ if (useHttp) {
     // Check if request is from localhost (for same-origin requests that don't send Origin header)
     // Use strict matching to prevent spoofing via subdomains like "malicious-localhost.evil.com"
     const host = req.headers.host || ''
-    const isLocalhostHost = host === `localhost:${port}` ||
+
+    // Extract hostnames from allowedOrigins for Host header validation
+    const allowedHosts = allowedOrigins.map(o => new URL(o).hostname)
+
+    const isAllowedHost = host === `localhost:${port}` ||
                             host === `127.0.0.1:${port}` ||
                             host === 'localhost' ||
-                            host === '127.0.0.1'
+                            host === '127.0.0.1' ||
+                            allowedHosts.includes(host)
 
     // Allow requests:
     // 1. With Origin header from localhost (any port) or production domains
-    // 2. Without Origin header if they're from localhost (same-origin requests)
+    // 2. Without Origin header if they're from localhost or allowed domains (same-origin requests)
     const isValidOrigin = origin
       ? (isLocalhostOrigin(origin) || allowedOrigins.includes(origin))
-      : isLocalhostHost
+      : isAllowedHost
 
     if (!isValidOrigin) {
       logger.warn(`Rejected request from invalid origin: ${origin || 'missing'} (host: ${host})`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socketsecurity/mcp",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "main": "./index.js",
   "bin": {


### PR DESCRIPTION
**Problem**: Same-origin requests from production domains (mcp.socket.dev, mcp.socket-staging.dev) were being rejected because browsers don't send an Origin header for same-origin requests, and the validation only allowed missing origins for localhost hosts.
**Solution**: Extended the Host header validation to also accept production domain hostnames, allowing same-origin requests from production environments to work correctly.

**Changes**:
- Added allowedHosts derived from allowedOrigins to validate Host headers
- Renamed isLocalhostHost → isAllowedHost to reflect broader scope
- Requests without an Origin header are now allowed if the Host matches localhost OR a production domain

Version bump: 0.0.15 → 0.0.16