### PR TITLE
Add Ruby gems and other ecosystems to depscore tool

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -88,7 +88,7 @@ function createConfiguredServer (): McpServer {
       description: "Get the dependency score of packages with the `depscore` tool from Socket. Use 'unknown' for version if not known. Use this tool to scan dependencies for their quality and security on existing code or when code is generated. Stop generating code and ask the user how to proceed when any of the scores are low. When checking dependencies, make sure to also check the imports in the code, not just the manifest files (pyproject.toml, package.json, etc).",
       inputSchema: {
         packages: z.array(z.object({
-          ecosystem: z.string().describe('The package ecosystem (e.g., npm, pypi)').default('npm'),
+          ecosystem: z.string().describe('The package ecosystem (e.g., npm, pypi, gem, golang, maven, nuget, cargo)').default('npm'),
           depname: z.string().describe('The name of the dependency'),
           version: z.string().describe("The version of the dependency, use 'unknown' if not known").default('unknown'),
         })).describe('Array of packages to check'),

--- a/test.ts
+++ b/test.ts
@@ -45,6 +45,7 @@ test('Socket MCP Server', async (t) => {
       { depname: 'lodash', ecosystem: 'npm', version: '4.17.21' },
       { depname: 'react', ecosystem: 'npm', version: '18.2.0' },
       { depname: 'requests', ecosystem: 'pypi', version: '2.31.0' },
+      { depname: 'puma', ecosystem: 'gem', version: '6.4.0' },
       { depname: 'unknown-package', ecosystem: 'npm', version: 'unknown' }
     ]
 
@@ -59,6 +60,30 @@ test('Socket MCP Server', async (t) => {
     assert.ok(result.content, 'Result should have content')
     assert.ok(Array.isArray(result.content), 'Content should be an array')
     assert.ok(result.content.length > 0, 'Content should not be empty')
+  })
+
+  await t.test('call depscore tool with gem ecosystem', async () => {
+    const gemPackages = [
+      { depname: 'puma', ecosystem: 'gem', version: '6.4.0' },
+      { depname: 'rails', ecosystem: 'gem', version: '7.1.0' },
+      { depname: 'nokogiri', ecosystem: 'gem', version: '1.16.0' }
+    ]
+
+    const result = await client.callTool({
+      name: 'depscore',
+      arguments: {
+        packages: gemPackages
+      }
+    })
+
+    assert.ok(result, 'Should get a result from depscore for gem packages')
+    assert.ok(result.content, 'Result should have content')
+    assert.ok(Array.isArray(result.content), 'Content should be an array')
+    assert.ok(result.content.length > 0, 'Content should not be empty')
+
+    const textContent = result.content[0] as { type: string; text: string }
+    assert.ok(textContent.text.includes('pkg:gem/'), 'Result should contain gem purl format')
+    assert.ok(!textContent.text.includes('No score found'), 'Gem packages should have scores')
   })
 
   await t.test('close client', async () => {


### PR DESCRIPTION
## Summary
- The Socket API already supports `gem`, `golang`, `maven`, `nuget`, and `cargo` ecosystems via PURL format, but the `depscore` tool description only listed `npm` and `pypi`
- AI clients (Claude Code, Cursor, etc.) use the tool description to determine supported ecosystems, so Ruby gems queries returned empty results
- Updated the ecosystem field description to list all supported ecosystems
- Added test coverage for gem packages (`puma`, `rails`, `nokogiri`)

## Test plan
- [x] All existing tests pass
- [x] New dedicated gem ecosystem test passes (verifies `pkg:gem/` format in results and scores returned)
- [x] Lint and type check pass
- [x] Manually verified Socket API returns scores for `pkg:gem/puma`, `pkg:gem/rails`, `pkg:gem/nokogiri`