### PR TITLE
docs: update ecosystem support from language-support docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Model Context Protocol (MCP) server for Socket integration, allowing AI assist
 
 ## ✨ Features
 
-- 🔍 **Dependency Security Scanning** - Get comprehensive security scores for npm, PyPI, and other package ecosystems
+- 🔍 **Dependency Security Scanning** - Get comprehensive security scores for npm, PyPI, cargo, Maven, NuGet, RubyGems, Go Modules, and more ([supported ecosystems](https://docs.socket.dev/docs/language-support))
 - 🌐 **Public Hosted Service** - Use our public server at `https://mcp.socket.dev/` with no setup required
 - 🚀 **Multiple Deployment Options** - Run locally via stdio, HTTP, or use our service
 - 🤖 **AI Assistant Integration** - Works seamlessly with Claude, VS Code Copilot, Cursor, and other MCP clients
@@ -234,9 +234,27 @@ The `depscore` tool allows AI assistants to query the Socket API for dependency 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `packages` | Array | ✅ Yes | - | Array of package objects to analyze |
-| `packages[].ecosystem` | String | No | `"npm"` | Package ecosystem (`npm`, `pypi`, `cargo`, etc.) |
+| `packages[].ecosystem` | String | No | `"npm"` | Package ecosystem. See [Supported Ecosystems](#supported-ecosystems) below. |
 | `packages[].depname` | String | ✅ Yes | - | Name of the dependency/package |
 | `packages[].version` | String | No | `"unknown"` | Version of the dependency |
+
+**Supported Ecosystems**
+
+Ecosystem support is based on [Socket's language support documentation](https://docs.socket.dev/docs/language-support). The `ecosystem` parameter maps to PURL types as follows:
+
+| Ecosystem | PURL type | Package managers | Maturity |
+|-----------|-----------|------------------|----------|
+| JavaScript & TypeScript | `npm` | npm, yarn, pnpm, Bun, VLT | GA |
+| Python | `pypi` | uv, pip, Poetry, Anaconda | GA |
+| Go | `golang` | Go Modules | GA |
+| Java | `maven` | Maven, Gradle | GA |
+| Ruby | `gem` | Bundler | GA |
+| .NET (C#, F#, VB) | `nuget` | NuGet | GA |
+| Scala | `maven` | sbt, Maven, Gradle | GA |
+| Kotlin | `maven` | Maven, Gradle | GA |
+| Rust | `cargo` | cargo | GA |
+| PHP | `composer` | Composer | Experimental |
+| GitHub Actions | `actions` | GitHub Actions workflows | Experimental (workflow scanning, not package-level) |
 
 **Example Usage:**
 

--- a/index.ts
+++ b/index.ts
@@ -392,7 +392,7 @@ function createConfiguredServer (): McpServer {
       description: "Get the dependency score of packages with the `depscore` tool from Socket. Use 'unknown' for version if not known. Use this tool to scan dependencies for their quality and security on existing code or when code is generated. Stop generating code and ask the user how to proceed when any of the scores are low. When checking dependencies, make sure to also check the imports in the code, not just the manifest files (pyproject.toml, package.json, etc).",
       inputSchema: {
         packages: z.array(z.object({
-          ecosystem: z.string().describe('The package ecosystem (e.g., npm, pypi, gem, golang, maven, nuget, cargo)').default('npm'),
+          ecosystem: z.string().describe('Package ecosystem (PURL type): npm (JS/TS), pypi (Python), golang (Go), maven (Java/Scala/Kotlin), gem (Ruby), nuget (.NET), cargo (Rust), composer (PHP). See https://docs.socket.dev/docs/language-support').default('npm'),
           depname: z.string().describe('The name of the dependency'),
           version: z.string().describe("The version of the dependency, use 'unknown' if not known").default('unknown'),
         })).describe('Array of packages to check'),

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Socket",
   "version": "0.0.13",
   "description": "Socket MCP server for scanning dependencies",
-  "long_description": "__Secure your code by default.__\nThe Socket MCP server brings powerful, real-time dependency scanning directly into Claude. Instantly audit packages from npm, PyPI, Cargo, and more—right inside your chats—with zero setup. Built on the Model Context Protocol (MCP), this extension automatically evaluates packages for:\n - Vulnerabilities and malware\n - Supply chain risks\n - Code quality and maintenance\n - License compliance\n\n With a single command, Claude will return detailed security scores (0–100) across five critical dimensions—helping you make informed decisions and avoid risky dependencies before they hit production.",
+  "long_description": "__Secure your code by default.__\nThe Socket MCP server brings powerful, real-time dependency scanning directly into Claude. Instantly audit packages from npm, PyPI, Cargo, Maven, NuGet, RubyGems, Go Modules, and more—right inside your chats—with zero setup. Built on the Model Context Protocol (MCP), this extension automatically evaluates packages for:\n - Vulnerabilities and malware\n - Supply chain risks\n - Code quality and maintenance\n - License compliance\n\n With a single command, Claude will return detailed security scores (0–100) across five critical dimensions—helping you make informed decisions and avoid risky dependencies before they hit production.",
   "author": {
     "name": "Socket",
     "email": "eng@socket.dev",
@@ -28,7 +28,7 @@
   "tools": [
     {
       "name": "depscore",
-      "description": "The depscore tool allows AI assistants to query the Socket API for dependency scoring information. It provides comprehensive security and quality metrics for packages across different ecosystems."
+      "description": "The depscore tool allows AI assistants to query the Socket API for dependency scoring information. It provides comprehensive security and quality metrics for packages across supported ecosystems: npm (JS/TS), pypi (Python), golang (Go), maven (Java/Scala/Kotlin), gem (Ruby), nuget (.NET), cargo (Rust), composer (PHP). See https://docs.socket.dev/docs/language-support"
     }
   ],
   "user_config": {


### PR DESCRIPTION
Update ecosystem support documentation to be concrete based on [Socket's language support docs](https://docs.socket.dev/docs/language-support). Excludes Socket Basics ecosystems.

## Changes
- **README**: Add Supported Ecosystems section with table (PURL types, package managers, maturity). Update Features and depscore parameter descriptions.
- **index.ts**: Update depscore tool ecosystem schema description with concrete list and docs link.
- **manifest.json**: Update tool description and long description with supported ecosystems.

## Public Changelog
<!-- changelog ⬇️-->
Documentation: Document supported package ecosystems (npm, pypi, golang, maven, gem, nuget, cargo, composer) with reference to Socket docs.
<!-- /changelog ⬆️ -->

## Checklist
- Is PR safe to revert (yes/no)?: yes

---
## Validation
- [x] TypeScript type check passed
- [x] Build succeeded
- [x] Lint passed
- [x] Unit tests passed (40/42; 2 require SOCKET_API_KEY for live API tests, run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)