### PR TITLE
docs(readme): use mcp-remote for claude desktop config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ Custom integrations are not available on every paid Claude plan. Check [Anthropi
    {
      "mcpServers": {
        "socket-mcp": {
-         "type": "http",
-         "url": "https://mcp.socket.dev/"
+         "command": "npx",
+         "args": [
+           "-y",
+           "mcp-remote@latest",
+           "https://mcp.socket.dev/"
+         ]
        }
      }
    }


### PR DESCRIPTION
## Summary
- Update the Claude Desktop manual-install JSON in README.md to launch the server via `npx -y mcp-remote@latest` instead of the raw `"type": "http"` transport block.

## Test plan
- [ ] Paste the updated config into Claude Desktop's `Edit Config` and confirm it connects to `https://mcp.socket.dev/`.