### PR TITLE
fix(origin): trust the hosted deployment's Host over a strict Origin allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,7 @@ Custom integrations are not available on every paid Claude plan. Check [Anthropi
      "mcpServers": {
        "socket-mcp": {
          "command": "npx",
-         "args": [
-           "-y",
-           "mcp-remote@latest",
-           "https://mcp.socket.dev/"
-         ]
+         "args": ["-y", "mcp-remote@latest", "https://mcp.socket.dev/"]
        }
      }
    }

--- a/lib/http-origin.ts
+++ b/lib/http-origin.ts
@@ -47,6 +47,21 @@ export function patchAcceptHeader(req: IncomingMessage): void {
 // Same-origin policy for the HTTP transport: allow localhost (any port),
 // production hosts, or Origin-less same-origin requests from matching
 // Host headers.
+//
+// The Origin check exists for DNS-rebinding protection: a malicious webpage
+// in a browser tab can reach a locally-bound MCP server through the user's
+// browser, so a localhost listener must reject cross-origin requests it
+// didn't expect. That threat model doesn't extend to the hosted deployment -
+// once a request has actually reached mcp.socket.dev/mcp.socket-staging.dev
+// (real public hosts, not a rebindable private listener), the only credential
+// that matters is the Bearer token authenticateRequest checks; there's no
+// ambient/cookie-based credential for a forged cross-origin request to ride
+// on. Gating the hosted host on a fixed Origin allowlist doesn't add real
+// CSRF protection there - it only breaks legitimate non-browser MCP clients
+// (Claude Desktop, Codex, etc.) whose HTTP stacks happen to set an Origin
+// header. So: once the request's Host matches a known hosted deployment, any
+// Origin (or none) passes; the strict allowlist stays in force for the
+// localhost/dev-rebinding case, which is the case it actually protects.
 export function validateOriginAndHost(
   origin: string,
   host: string,
@@ -59,9 +74,13 @@ export function validateOriginAndHost(
     host === 'localhost' ||
     host === '127.0.0.1' ||
     allowedHosts.includes(host)
-  return origin
-    ? isLocalhostOrigin(origin) || ALLOWED_ORIGINS.includes(origin)
-    : isAllowedHost
+  if (!origin) {
+    return isAllowedHost
+  }
+  if (allowedHosts.includes(host)) {
+    return true
+  }
+  return isLocalhostOrigin(origin) || ALLOWED_ORIGINS.includes(origin)
 }
 
 // Wire CORS response headers when the request carried an Origin. We

--- a/test/unit/http-origin.fuzz.test.mts
+++ b/test/unit/http-origin.fuzz.test.mts
@@ -7,7 +7,9 @@
  *   - `isLocalhostOrigin` returns a boolean for ANY string (never throws), true
  *     iff the URL's hostname is `localhost` or `127.0.0.1`.
  *   - `validateOriginAndHost` allows a request iff (origin present) the origin is
- *     localhost or on the production allow-list, or (origin absent) the host
+ *     localhost or on the production allow-list or the Host itself is an
+ *     allow-listed hosted deployment (Bearer-token auth, not Origin, gates that
+ *     case - see the doc comment on the function), or (origin absent) the host
  *     matches localhost / 127.0.0.1 (with or without the bound port) or an
  *     allow-listed production host. It never throws. Properties CONSTRUCT
  *     origins/hosts whose verdict is known up front rather than reimplementing
@@ -105,13 +107,34 @@ describe('lib/http-origin validateOriginAndHost (fuzz)', () => {
     )
   })
 
-  // A present-but-unlisted public origin is rejected regardless of host: when
-  // an origin is sent the host branch is not consulted.
-  test('an unlisted public origin is rejected regardless of host', () => {
+  // A present-but-unlisted public origin is rejected unless the Host itself
+  // is an allow-listed hosted deployment - the fixed exception documented on
+  // the function.
+  test('an unlisted public origin is rejected against a non-hosted host', () => {
     fc.assert(
-      fc.property(publicOrigin, fc.string(), port, (origin, host, p) => {
-        expect(validateOriginAndHost(origin, host, p)).toBe(false)
-      }),
+      fc.property(
+        publicOrigin,
+        word.map(w => `${w}.example.com`),
+        port,
+        (origin, host, p) => {
+          expect(validateOriginAndHost(origin, host, p)).toBe(false)
+        },
+      ),
+    )
+  })
+
+  // A present-but-unlisted public origin is accepted once the Host matches a
+  // hosted deployment: Bearer-token auth gates that case, not Origin.
+  test('an unlisted public origin is accepted against an allow-listed host', () => {
+    fc.assert(
+      fc.property(
+        publicOrigin,
+        fc.constantFrom(...ALLOWED_HOSTS),
+        port,
+        (origin, host, p) => {
+          expect(validateOriginAndHost(origin, host, p)).toBe(true)
+        },
+      ),
     )
   })
 

--- a/test/unit/http-origin.test.mts
+++ b/test/unit/http-origin.test.mts
@@ -43,10 +43,26 @@ describe('validateOriginAndHost', () => {
     ).toBe(true)
   })
 
-  test('rejects a non-allow-listed origin', () => {
+  test('rejects a non-allow-listed origin against a localhost host', () => {
     expect(
       validateOriginAndHost('https://evil.example.com', 'localhost:3000', 3000),
     ).toBe(false)
+  })
+
+  test('allows a non-allow-listed origin once the Host matches the hosted deployment', () => {
+    // Claude Desktop's custom connector (and other native MCP clients) send
+    // an Origin header their HTTP stack sets automatically; Bearer-token
+    // auth, not Origin, is what actually gates the hosted deployment.
+    expect(
+      validateOriginAndHost('https://claude.ai', 'mcp.socket.dev', 3000),
+    ).toBe(true)
+    expect(
+      validateOriginAndHost(
+        'https://chatgpt.com',
+        'mcp.socket-staging.dev',
+        3000,
+      ),
+    ).toBe(true)
   })
 
   test('falls back to host check when no origin is sent', () => {

--- a/test/unit/http-server.test.mts
+++ b/test/unit/http-server.test.mts
@@ -131,6 +131,26 @@ describe('routeRequest', () => {
     expect(calls).toHaveLength(0)
   })
 
+  test('reaches the MCP handler when the Origin is a native client against the hosted host', async () => {
+    // Claude Desktop's custom connector sends Origin: https://claude.ai
+    // against Host: mcp.socket.dev. That combination used to 403 before ever
+    // reaching OAuth discovery or the MCP handler - this is the regression
+    // test for that report.
+    const { res } = makeRes()
+    const { calls, handler } = recordingMcpHandler()
+    await routeRequest(
+      handler,
+      plainReq({
+        url: '/',
+        method: 'GET',
+        headers: { origin: 'https://claude.ai', host: 'mcp.socket.dev' },
+      }),
+      res,
+      3000,
+    )
+    expect(calls).toHaveLength(1)
+  })
+
   test('answers an OPTIONS preflight with CORS headers', async () => {
     const { captured, res } = makeRes()
     const { handler } = recordingMcpHandler()


### PR DESCRIPTION
LLM Description written by Claude Code:Claude Sonnet 5
-----
Fixes Claude Desktop's custom connector failing to connect (SURF-1613), and likely the same symptom Codex desktop hits (SURF-1148).

<details>
<summary>Root cause</summary>

`validateOriginAndHost` gates every request (including OAuth discovery) on a fixed Origin allowlist. Claude Desktop's connector sends `Origin: https://claude.ai`, which isn't on that list, so it gets a bare 403 before ever reaching OAuth discovery - it never learns to start the auth flow.

That Origin check exists for DNS-rebinding protection: a malicious webpage in a browser tab could otherwise reach a locally-bound MCP server through the user's browser. That threat model doesn't extend to the hosted deployment - `mcp.socket.dev`/`mcp.socket-staging.dev` are real public hosts, not rebindable private listeners, and the only credential that matters there is the Bearer token `authenticateRequest` checks (RFC 6750, no cookies involved). Gating the hosted host on a fixed Origin allowlist doesn't add real CSRF protection; it just breaks any non-browser MCP client whose HTTP stack happens to set an Origin header - which will keep recurring as new MCP clients show up (Claude Desktop today, Codex tomorrow).
</details>

<details>
<summary>Fix</summary>

Once `Host` matches a known hosted deployment, any Origin (or none) now passes. The strict allowlist stays in force for the localhost/dev case, which is the DNS-rebinding threat it actually protects against.
</details>

Test plan: `pnpm run test --all` - 505/505 pass (1 pre-existing e2e failure, confirmed present on a clean `origin/main` checkout too, unrelated to this change - a `@socketsecurity/lib` module-resolution gap in this environment). Added unit + fuzz coverage for the new Host-based exception, plus an integration-level regression test reproducing the exact reported Claude Desktop request shape.