### PR TITLE
docs(readme): stop recommending npx and pnpm dlx

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,8 @@ Custom integrations are not available on every paid Claude plan. Check [Anthropi
    {
      "mcpServers": {
        "socket-mcp": {
-         "command": "npx",
-         "args": [
-           "-y",
-           "mcp-remote@latest",
-           "https://mcp.socket.dev/"
-         ]
+         "type": "http",
+         "url": "https://mcp.socket.dev/"
        }
      }
    }
@@ -149,12 +145,18 @@ Self-hosting keeps every request inside your own infrastructure. It needs a Sock
 
 Stdio is the default and the right answer for a single developer. Choose HTTP when more than one person, or something that is not a local process, needs to reach the server.
 
+Install it once, globally, before either option:
+
+```sh
+pnpm add -g @socketsecurity/mcp
+```
+
 <details><summary><b>Option 2a - Stdio mode (default)</b></summary>
 
 Claude Code:
 
 ```sh
-claude mcp add socket-mcp -e SOCKET_API_TOKEN="your-api-token-here" -- pnpm dlx @socketsecurity/mcp@latest
+claude mcp add socket-mcp -e SOCKET_API_TOKEN="your-api-token-here" -- socket-mcp
 ```
 
 Most other MCP clients:
@@ -163,8 +165,7 @@ Most other MCP clients:
 {
   "mcpServers": {
     "socket-mcp": {
-      "command": "npx",
-      "args": ["@socketsecurity/mcp@latest"],
+      "command": "socket-mcp",
       "env": {
         "SOCKET_API_TOKEN": "your-api-token-here"
       }
@@ -177,10 +178,10 @@ Most other MCP clients:
 
 <details><summary><b>Option 2b - HTTP mode</b></summary>
 
-Run the server in HTTP mode with pnpm dlx:
+Run the server in HTTP mode:
 
 ```sh
-MCP_HTTP_MODE=true SOCKET_API_TOKEN=your-api-token pnpm dlx @socketsecurity/mcp@latest --http
+MCP_HTTP_MODE=true SOCKET_API_TOKEN=your-api-token socket-mcp --http
 ```
 
 The server listens on `http://localhost:3000/`. The MCP endpoint is `/` and the health endpoint is `/health`; every other path answers `404`.
@@ -233,7 +234,7 @@ MCP_HTTP_MODE=true \
 SOCKET_OAUTH_ISSUER=https://issuer.example.com \
 SOCKET_OAUTH_INTROSPECTION_CLIENT_ID=your-client-id \
 SOCKET_OAUTH_INTROSPECTION_CLIENT_SECRET=your-client-secret \
-pnpm dlx @socketsecurity/mcp@latest --http
+socket-mcp --http
 ```
 
 With OAuth enabled, every request to the MCP endpoint goes through RFC 7662 token introspection. A raw Socket API token is rejected with a `401`, whatever its prefix; a `sktsec_` token is no more privileged than any other string here. Callers send an OAuth access token, and the server uses that token for the Socket API calls it makes on their behalf. Run without the OAuth variables to accept raw Socket API tokens instead.
@@ -303,7 +304,7 @@ Query the Socket API for dependency scoring information. Returns supply chain, q
 | `packages[].version`   | String | No       | `"unknown"` | Version of the dependency                                                                                                                                                                |
 | `platform`             | String | No       | -           | OS-architecture hint (`linux-x64`, `darwin-arm64`, `win32-x64`) applied to every package in the request. Picks the most relevant artifact when a package ships platform-specific builds. |
 
-**Supported ecosystems**
+##### Supported ecosystems
 
 Based on [Socket's language support](https://docs.socket.dev/docs/language-support). The `ecosystem` parameter maps to PURL types:
 

--- a/docs/mock-client-debugging.md
+++ b/docs/mock-client-debugging.md
@@ -126,7 +126,7 @@ The spec wants both content types in `Accept`. The server rewrites a missing or
 partial `Accept` header before the MCP handler sees it, so a bare `curl` also
 works, but a real client should send both.
 
-The response is a Server-Sent Events stream, so the JSON arrives on a `data: `
+The response is a Server-Sent Events stream, so the JSON arrives on a `data:`
 line rather than as a bare body.
 
 Sending an `Origin` header that does not name this server gets a `403`. Omitting


### PR DESCRIPTION
LLM Description written by Claude Code:Claude Sonnet 5
-----
Stops promoting `npx`/`pnpm dlx` in the README, per direction not to lead docs with fetch-and-run install patterns.

<details>
<summary>Changes</summary>

- **Claude Desktop manual install**: was using `npx -y mcp-remote@latest` as a bridge because the native `"type": "http"` transport was broken by the Origin-allowlist bug (#213 worked around it). That's now fixed in #214, so this restores the same native config VS Code and Cursor already document, dropping the `mcp-remote` dependency entirely.
- **Self-hosting (Option 2a/2b)**: was invoking `socket-mcp` via `npx`/`pnpm dlx` on every command instead of installing it. Added a one-time `pnpm add -g @socketsecurity/mcp` step and reference the `socket-mcp` binary directly everywhere after.
- Two pre-existing markdownlint violations surfaced once `--all` ran on this repo, fixed alongside: a bold-text-as-heading in README.md, and a trailing space inside a code span in docs/mock-client-debugging.md.
</details>

Test plan: `LINT_MARKDOWN=1 pnpm run lint --all` - 0 issues. Docs-only change, no code paths touched.